### PR TITLE
-print-to fix

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -69,7 +69,7 @@ pub fn print_pdf (options: PrintOptions) -> String {
     let dir: std::path::PathBuf = env::temp_dir();
     let print_setting: String = options.print_setting;
     let mut print: String = "-print-to-default".to_owned();
-    if options.id.len() == 0 {
+    if options.id.len() != 0 {
         print = format!("-print-to {}", options.id).to_owned();
     }
     let shell_command = format!("{}sm.exe {} {} -silent {}", dir.display(), print, print_setting, options.path);


### PR DESCRIPTION
First of all, thanks for creating this crate, saved me a bunch of time already.

But the example from the readme isn't working properly if you give it a printer id.
```
await print_file({
    id: "idfromlistprinter",
    path: 'F:/path/to/file.pdf',
})
```
The print always gets send to the default printer, regardless of the id passed through.

The issue seems to be the `==`, right now it only sets `-print-to` if the printer id is empty.